### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the GitHub Skills activity that was announced by the principal but was missing from the student signup system.

## Related Issue
Fixes #6 

## Changes Made
- ✅ Added "GitHub Skills" as a new extracurricular activity
- ✅ Description includes mention of GitHub Certifications program for college applications
- ✅ Set maximum participants to 25 students
- ✅ Scheduled for Mondays and Wednesdays, 3:30 PM - 5:00 PM
- ✅ Initialized with empty participant list (ready for student signups)

## Testing
- Activity data follows the same structure as existing activities
- No breaking changes to the API
- Students can now view and register for GitHub Skills activity

## Priority
⏰ **Time-sensitive**: Registration closes by end of week per principal's announcement